### PR TITLE
Add `allow_diff` function to alllow some diff by regex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run shellcheck tests
       run: shellcheck -x test/approve

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Approvals.bash - Bash Interactive Approval Testing
 
-![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)
+![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)
 [![Build Status](https://github.com/DannyBen/approvals.bash/workflows/Test/badge.svg)](https://github.com/DannyBen/approvals.bash/actions?query=workflow%3ATest)
 
 ---
@@ -89,6 +89,18 @@ approve "some-command --that --fails" || return 0
 expect_exit_code 1
 ```
 
+
+### Allowing some difference
+
+In case the command under test outputs slightly different values each run,
+you can use the `allow_diff <regex>` command. This regex will be replaced
+with an asterisk (`*`) in the actual output in the following `approve` call
+(once only).
+
+```bash
+allow_diff "[0-9]\+"
+approve "date"
+```
 
 ### Triggering custom failures
 

--- a/approvals.bash
+++ b/approvals.bash
@@ -1,4 +1,4 @@
-# approvals.bash v0.3.3
+# approvals.bash v0.4.0
 #
 # Interactive approval testing for Bash.
 # https://github.com/DannyBen/approvals.bash
@@ -9,6 +9,10 @@ approve() {
   cmd=$1
   last_exit_code=0
   actual=$(eval "$cmd" 2>&1) || last_exit_code=$?
+  if [[ "$allow_diff_regex" ]]; then
+    actual=$(echo "$actual" | sed "s/$allow_diff_regex/*/g")
+    unset allow_diff_regex
+  fi
   approval=$(printf "%b" "$cmd" | tr -s -c "[:alnum:]" _)
   approval_file="$approvals_dir/${2:-"$approval"}"
 
@@ -33,6 +37,10 @@ approve() {
     echo "--- [$(blue "diff: $cmd")] ---"
     user_approval "$cmd" "$actual" "$approval_file"
   fi
+}
+
+allow_diff() {
+  allow_diff_regex="$1"
 }
 
 describe() {

--- a/op.conf
+++ b/op.conf
@@ -1,4 +1,5 @@
 test: shellcheck -x test/approve && test/approve
-#? Run shellcheck tests and approval tests
+#? run shellcheck tests and approval tests
 
-fmt: shfmt -d -i 2 -ci approvals.bash && echo "OK"
+fmt: shfmt -d -i 2 -ci approvals.bash && echo "PASS"
+#? run shfmt tests

--- a/test/approvals/_sample_cli_app_sh_random
+++ b/test/approvals/_sample_cli_app_sh_random
@@ -1,0 +1,1 @@
+This line contains changing output [*]

--- a/test/approve
+++ b/test/approve
@@ -14,6 +14,10 @@ context "standard operation"
     approve "./sample-cli-app.sh say hello"
     approve "./sample-cli-app.sh say hello" "alternative_fixture_file"
 
+    # ignore the part matching this regex in the following approve call
+    allow_diff "[0-9]\+"
+    approve "./sample-cli-app.sh random"
+
 context "when APPROVALS_DIR is set"
   APPROVALS_DIR=alt-approvals
   

--- a/test/sample-cli-app.sh
+++ b/test/sample-cli-app.sh
@@ -6,6 +6,8 @@ if [[ $1 = "--help" ]]; then
   echo "  sample-cli-app --help"
 elif [[ $1 = "say" ]]; then
   echo "${2:-hi}"
+elif [[ $1 = "random" ]]; then
+  echo "This line contains changing output [$RANDOM]"
 else
   echo "Run sample-cli-app --help for help"
 fi


### PR DESCRIPTION
In case the command under test outputs slightly different values each run, you can use the `allow_diff <regex>` command. This regex will be replaced with an asterisk (`*`) in the actual output in the following `approve` call (once only).

```bash
allow_diff "[0-9]\+"
approve "date"
```