### PR TITLE
Make output format more compact

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = coverage,tmp,Gemfile.lock,sublime*
+; ignore-words-list = rouge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run shellcheck tests
-      run: shellcheck -x test/approve
+      run: shellcheck -x test/approve approvals.bash && echo "PASS"
 
     - name: Run approval tests
       run: test/approve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ v0.4.1 - 2024-01-05
 - Update `allow_diff` to check with `sed -E` instead of just `sed`
 
 
+<!-- break v0.4.0 -->
 v0.4.0 - 2023-08-28
 ----------------------------------------
 
 - Fix exit codes on failure and apply set -e
 - Improve error handling and output
-- Add `allow_diff` function to alllow some diff by regex
+- Add `allow_diff` function to allow some diff by regex
 
 

--- a/op.conf
+++ b/op.conf
@@ -1,7 +1,7 @@
 test: test/approve
 #? run approval tests
 
-shellcheck: shellcheck -x test/approve approvals.bash  && echo "PASS"
+shellcheck: shellcheck -x test/approve approvals.bash && echo "PASS"
 #? run shellcheck tests
 
 shfmt: shfmt -d -i 2 -ci approvals.bash && echo "PASS"

--- a/op.conf
+++ b/op.conf
@@ -1,8 +1,8 @@
-test: shellcheck -x test/approve && test/approve
-#? run shellcheck tests and approval tests
+test: test/approve
+#? run approval tests
 
-fmt: shfmt -d -i 2 -ci approvals.bash && echo "PASS"
-#? run shfmt tests
+shellcheck: shellcheck -x test/approve approvals.bash  && echo "PASS"
+#? run shellcheck tests
 
-check: shellcheck approvals.bash && echo "PASS"
+shfmt: shfmt -d -i 2 -ci approvals.bash && echo "PASS"
 #? run shfmt tests

--- a/test/approve
+++ b/test/approve
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run this from the root directory
 
-# Soure the approvals script
+# Source the approvals script
 source "approvals.bash"
 
 # Test commands


### PR DESCRIPTION
- Add codespell configuration and fix typos
- Fix calls to shellcheck
- Move all output strings to variables for easy change
- Update all output strings