### PR TITLE
Add `it` annotation and reduce annotation color noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can test the exit code of the last approved command by using the
 For example:
 
 ```bash
-approve "some-command --that --fails" || return 0
+approve "some-command --that --fails"
 expect_exit_code 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,27 +57,28 @@ approve "ls -s" "ls_size"
 ```
 
 
-### Adding `context` and `describe` annotations
+### Annotation commands (`context`, `describe`, `it`)
 
-If your apptovals test files become too long or complex, you may use the
-`describe` and `context` commands to annotate your tests. These commands are
-purely decorative and will output the provided strings as captions.
+If your apptovals test files become too long or complex, you may the
+`describe`, `context` or `it` commands to annotate your tests. These commands
+are purely decorative and will output the provided strings as captions.
 
 ```bash
-context "basic operations"
-  describe "test ls"
-    approve "ls -s"
+describe "ls"
+  it "shows the list of files"
+    approve "ls"
 
 context "when in a non-empty directory"
   cd ./tmp
-  describe "test ls in another directory"
+  describe "ls -s"
     approve "ls -s"
     approve "ls -s" "ls_size"
   
   cd ../
 ```
 
-The indentation is optional.
+You can use any of the annotation commands, in any order. The indentation is
+optional.
 
 
 ### Testing exit code

--- a/approvals.bash
+++ b/approvals.bash
@@ -54,6 +54,10 @@ context() {
   printf "$context_string\n" "$*"
 }
 
+it() {
+  printf "$it_string\n" "$*"
+}
+
 fail() {
   printf "$fail_string\n" "$*"
   exit 1
@@ -72,15 +76,38 @@ expect_exit_code() {
   fi
 }
 
-bold() { printf "\e[1m%b\e[0m\n" "$*"; }
-blue() { printf "\e[34m%b\e[0m\n" "$*"; }
-cyan() { printf "\e[36m%b\e[0m\n" "$*"; }
-green() { printf "\e[32m%b\e[0m\n" "$*"; }
-magenta() { printf "\e[35m%b\e[0m\n" "$*"; }
-red() { printf "\e[31m%b\e[0m\n" "$*"; }
-yellow() { printf "\e[33m%b\e[0m\n" "$*"; }
-
 # Private
+
+print_in_color() {
+  local color="$1"
+  shift
+  if [[ -z ${NO_COLOR+x} ]]; then
+    printf "$color%b\e[0m\n" "$*"
+  else
+    printf "%b\n" "$*"
+  fi
+}
+
+red() { print_in_color "\e[31m" "$*"; }
+green() { print_in_color "\e[32m" "$*"; }
+yellow() { print_in_color "\e[33m" "$*"; }
+blue() { print_in_color "\e[34m" "$*"; }
+magenta() { print_in_color "\e[35m" "$*"; }
+cyan() { print_in_color "\e[36m" "$*"; }
+bold() { print_in_color "\e[1m" "$*"; }
+underlined() { print_in_color "\e[4m" "$*"; }
+red_bold() { print_in_color "\e[1;31m" "$*"; }
+green_bold() { print_in_color "\e[1;32m" "$*"; }
+yellow_bold() { print_in_color "\e[1;33m" "$*"; }
+blue_bold() { print_in_color "\e[1;34m" "$*"; }
+magenta_bold() { print_in_color "\e[1;35m" "$*"; }
+cyan_bold() { print_in_color "\e[1;36m" "$*"; }
+red_underlined() { print_in_color "\e[4;31m" "$*"; }
+green_underlined() { print_in_color "\e[4;32m" "$*"; }
+yellow_underlined() { print_in_color "\e[4;33m" "$*"; }
+blue_underlined() { print_in_color "\e[4;34m" "$*"; }
+magenta_underlined() { print_in_color "\e[4;35m" "$*"; }
+cyan_underlined() { print_in_color "\e[4;36m" "$*"; }
 
 user_approval() {
   local cmd="$1"
@@ -127,8 +154,9 @@ set -e
 trap 'onexit' EXIT
 trap 'onerror' ERR
 
-describe_string="$(blue ▌ describe)   %s"
-context_string="$(magenta ▌ context)    %s"
+describe_string="$(bold ▌ describe)   %s"
+context_string="$(bold ▌ context)    %s"
+it_string="$(bold ▌ it)         %s"
 fail_string="  $(red FAILED)     %s"
 pass_string="  $(green approved)   %s"
 exit_success_string="$(green ▌ exit)       $(bold %s finished successfully)"

--- a/approvals.bash
+++ b/approvals.bash
@@ -157,12 +157,12 @@ trap 'onerror' ERR
 describe_string="$(bold ▌ describe)   %s"
 context_string="$(bold ▌ context)    %s"
 it_string="$(bold ▌ it)         %s"
-fail_string="  $(red FAILED)     %s"
+fail_string="  $(red_bold failed)     %s"
 pass_string="  $(green approved)   %s"
 exit_success_string="$(green ▌ exit)       $(bold %s finished successfully)"
-exit_failed_string="$(red ▌ exit)       $(bold %s finished with errors)"
+exit_failed_string="$(red_bold ▌ exit)       $(bold %s finished with errors)"
 new_diff_string="────┤ $(yellow new): $(bold %s) ├────"
-changed_diff_string="────┤ $(cyan changed): $(bold %s) ├────"
+changed_diff_string="────┤ $(blue changed): $(bold %s) ├────"
 approval_string="[A]pprove? "
 
 if diff --help | grep -- --color >/dev/null 2>&1; then

--- a/test/approvals/ls_no_such_dir
+++ b/test/approvals/ls_no_such_dir
@@ -1,0 +1,1 @@
+ls: cannot access 'no-such-dir': No such file or directory

--- a/test/approve
+++ b/test/approve
@@ -21,7 +21,7 @@ context "standard operation"
 context "when APPROVALS_DIR is set"
   APPROVALS_DIR=alt-approvals
   
-  describe "writes approvals to a different directory"
+  it "writes approvals to a different directory"
     approve "./sample-cli-app.sh"
   
   unset APPROVALS_DIR
@@ -30,7 +30,7 @@ context "when AUTO_APPROVE is set"
   AUTO_APPROVE=1
   rm -f approvals/ls
 
-  describe "writes approvals without prompting the user"
+  it "writes approvals without prompting the user"
     approve "ls"
 
   unset AUTO_APPROVE

--- a/test/approve
+++ b/test/approve
@@ -4,33 +4,41 @@
 # Source the approvals script
 source "approvals.bash"
 
-# Test commands
+# Test everything inside the test directory
 cd ./test || exit
-context "standard operation"
-  describe "sample cli test"
-    approve "./sample-cli-app.sh"
-    approve "./sample-cli-app.sh --help"
-    approve "./sample-cli-app.sh say"
-    approve "./sample-cli-app.sh say hello"
-    approve "./sample-cli-app.sh say hello" "alternative_fixture_file"
 
-    # ignore the part matching this regex in the following approve call
+# Test commands
+describe "approve"
+  approve "./sample-cli-app.sh"
+  approve "./sample-cli-app.sh --help"
+  approve "./sample-cli-app.sh say"
+  approve "./sample-cli-app.sh say hello"
+  approve "./sample-cli-app.sh say hello" "alternative_fixture_file"
+
+  context "when APPROVALS_DIR is set"
+    APPROVALS_DIR=alt-approvals
+
+    it "writes approvals to a different directory"
+      approve "./sample-cli-app.sh"
+
+    unset APPROVALS_DIR
+
+  context "when AUTO_APPROVE is set"
+    AUTO_APPROVE=1
+    rm -f approvals/ls
+
+    it "writes approvals without prompting the user"
+      approve "ls"
+
+    unset AUTO_APPROVE
+
+describe "allow_diff"
+  it "ignores anything matching the regex in the next approve call"
     allow_diff "[0-9]+"
     approve "./sample-cli-app.sh random"
 
-context "when APPROVALS_DIR is set"
-  APPROVALS_DIR=alt-approvals
-  
-  it "writes approvals to a different directory"
-    approve "./sample-cli-app.sh"
-  
-  unset APPROVALS_DIR
-
-context "when AUTO_APPROVE is set"
-  AUTO_APPROVE=1
-  rm -f approvals/ls
-
-  it "writes approvals without prompting the user"
-    approve "ls"
-
-  unset AUTO_APPROVE
+describe "expect_exit_code"
+  context "when the previous approve exited with the expected code"
+    it "passes"
+      approve "ls no-such-dir"
+      expect_exit_code 2


### PR DESCRIPTION
In this PR:

1. New `it` annotation, to join `context` and `describe`. This is also purely decorative, and serves to allow creating easy to read tests, à la RSpec.
2. All annotation commands have been set to output as bold, without color to reduce the meaningless color noise.
